### PR TITLE
downgrade to c++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(fmu4cpp-template VERSION ${projectVersion})
 
 option(FMU4CPP_BUILD_TESTS "Build internal tests" OFF)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 if (MSVC)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif ()

--- a/export/examples/SimplePendulum/simple_pendulum.cpp
+++ b/export/examples/SimplePendulum/simple_pendulum.cpp
@@ -1,8 +1,8 @@
 
 #include <fmu4cpp/fmu_base.hpp>
 
+#define _USE_MATH_DEFINES
 #include <cmath>
-#include <numbers>
 
 using namespace fmu4cpp;
 
@@ -42,7 +42,7 @@ public:
     }
 
     void reset() override {
-        angle_ = std::numbers::pi / 4;// 45 degrees
+        angle_ = M_PI / 4;// 45 degrees
         angularVelocity_ = 0;
         gravity_ = -9.81;
         length_ = 1.0;

--- a/export/src/CMakeLists.txt
+++ b/export/src/CMakeLists.txt
@@ -46,7 +46,7 @@ add_library(fmu4cpp OBJECT
         "${privateHeadersFull}"
         "${sources}"
         )
-target_compile_features(fmu4cpp PUBLIC "cxx_std_20")
+target_compile_features(fmu4cpp PUBLIC "cxx_std_17")
 set_target_properties(fmu4cpp PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(fmu4cpp
         PUBLIC

--- a/export/src/fmu4cpp/fmu_base.cpp
+++ b/export/src/fmu4cpp/fmu_base.cpp
@@ -96,7 +96,7 @@ namespace fmu4cpp {
         ss << "\t<ModelVariables>\n";
 
         auto allVars = collect(integers_, reals_, booleans_, strings_);
-        std::ranges::sort(allVars, [](const VariableBase *v1, const VariableBase *v2) {
+        std::sort(allVars.begin(), allVars.end(), [](const VariableBase* v1, const VariableBase* v2) {
             return v1->index() < v2->index();
         });
 


### PR DESCRIPTION
This enables to build the core/base library with c++17. 

One can still add a newer (or even older) c++ version for the actual code of the model itself - if required.

Closes #21 