### PR TITLE
add Annotations

### DIFF
--- a/export/examples/SimplePendulum/simple_pendulum.cpp
+++ b/export/examples/SimplePendulum/simple_pendulum.cpp
@@ -30,7 +30,8 @@ public:
         register_variable(real(
                                   "damping", &damping_)
                                   .setCausality(causality_t::PARAMETER)
-                                  .setVariability(variability_t::FIXED));
+                                  .setVariability(variability_t::FIXED)
+                                  .addAnnotation("<Tool name=\"fmu4cpp\">\n\t<documentation>\"Example of tool specific variable annotation\"</documentation>\n</Tool>"));
 
         SimplePendulum::reset();
     }
@@ -63,6 +64,7 @@ model_info fmu4cpp::get_model_info() {
     info.modelName = "SimplePendulum";
     info.description = "A simple pendulum model";
     info.modelIdentifier = FMU4CPP_MODEL_IDENTIFIER;
+    info.vendorAnnotations = {"<Tool name=\"fmu4cpp\">\n\t<documentation>\"Example of tool specific annotation data\"</documentation>\n</Tool>"};
     return info;
 }
 

--- a/export/include/fmu4cpp/fmu_variable.hpp
+++ b/export/include/fmu4cpp/fmu_variable.hpp
@@ -46,7 +46,7 @@ namespace fmu4cpp {
         causality_t causality_ = causality_t::LOCAL;
         std::optional<variability_t> variability_;
         std::optional<initial_t> initial_;
-
+        std::vector<std::string> annotations_;
         std::vector<size_t> dependencies_;
 
     public:
@@ -82,6 +82,10 @@ namespace fmu4cpp {
                 throw std::logic_error("Can only declare dependencies for outputs!");
             }
             return dependencies_;
+        }
+
+        [[nodiscard]] std::vector<std::string> getAnnotations() const {
+            return annotations_;
         }
 
         virtual ~VariableBase() = default;
@@ -141,6 +145,18 @@ namespace fmu4cpp {
             for (auto i: dependencies) {
                 dependencies_.emplace_back(i);
             }
+            return *static_cast<V *>(this);
+        }
+
+        V &setAnnotations(const std::vector<std::string> &annotations) {
+            for (auto i: annotations) {
+                annotations_.emplace_back(i);
+            }
+            return *static_cast<V *>(this);
+        }
+
+        V &addAnnotation(const std::string &annotation) {
+            annotations_.emplace_back(annotation);
             return *static_cast<V *>(this);
         }
 

--- a/export/include/fmu4cpp/model_info.hpp
+++ b/export/include/fmu4cpp/model_info.hpp
@@ -13,6 +13,7 @@ namespace fmu4cpp {
         std::string modelIdentifier;
         std::string version;
         std::string variableNamingConvention{"structured"};
+        std::vector<std::string> vendorAnnotations;
         bool needsExecutionTool{false};
         bool canHandleVariableCommunicationStepSize{true};
         bool canBeInstantiatedOnlyOncePerProcess{false};


### PR DESCRIPTION
For us to be able to package FMUs according to the [osi-sensor-model-packaging](https://github.com/OpenSimulationInterface/osi-sensor-model-packaging/tree/961f01a352b8b7448bf198b659516bd623db3c4f) specification it is required to add `VendorAnnotations` and variable `Annotations` to the `modelDescription.xml`. It would be nice to have such a functionality inside fmu4cpp similar to `register_variable()`, `setCausality()` etc.

According to the [FMI docs](https://github.com/modelica/fmi-standard/releases/tag/v2.0.5) `VendorAnnotations`  as well as  `Annotations`  "[...] can be an arbitrary XML data structure". This would mean that user must be able to set xml in the model source file and the beauty of fmu4cpp by abstracting xml to function call is thus a bit reduced - but only for users requiring those fields. 

I added the required functions and added them for demonstration to the `simple_pendelum` example file. I tired to keep it as close as possible to the existing style.

 <details>

<summary>The resulting ModelDescription.xml looks like this: </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>  
<fmiModelDescription fmiVersion="2.0" modelName="SimplePendulum" guid="1875144255117804970" generationTool="fmu4cpp v0.3.0" generationDateAndTime="2025-01-03T09:41:35Z" description="A simple pendulum model" author="" variableNamingConvention="structured">  
    <CoSimulation needsExecutionTool="false" modelIdentifier="simple_pendulum" canHandleVariableCommunicationStepSize="true" canBeInstantiatedOnlyOncePerProcess="false" canGetAndSetFMUstate="false" canSerializeFMUstate="false" canNotUseMemoryManagementFunctions="true">  
    </CoSimulation>  
    <VendorAnnotations>  
          <Tool name="fmu4cpp">  
             <documentation>"Example of tool specific annotation data"</documentation>  
          </Tool>  
    </VendorAnnotations>  
    <ModelVariables>  
       <!--index=1-->  
       <ScalarVariable name="angle" valueReference="0" causality="output" variability="continuous">  
          <Real/>  
       </ScalarVariable>  
       <!--index=2-->  
       <ScalarVariable name="angularVelocity" valueReference="1" causality="local" variability="continuous">  
          <Real/>  
       </ScalarVariable>  
       <!--index=3-->  
       <ScalarVariable name="gravity" valueReference="2" causality="parameter" variability="fixed">  
          <Real start="-9.81"/>  
       </ScalarVariable>  
       <!--index=4-->  
       <ScalarVariable name="length" valueReference="3" causality="parameter" variability="fixed">  
          <Real start="1"/>  
       </ScalarVariable>  
       <!--index=5-->  
       <ScalarVariable name="damping" valueReference="4" causality="parameter" variability="fixed">  
          <Real start="0.1"/>  
          <Annotations>  
             <Tool name="fmu4cpp">  
                <documentation>"Example of tool specific variable annotation"</documentation>  
             </Tool>  
          </Annotations>  
       </ScalarVariable>  
    </ModelVariables>  
    <ModelStructure>  
       <Outputs>  
          <Unknown index="1"/>  
       </Outputs>  
    </ModelStructure>  
</fmiModelDescription>

```

</details>