### PR TITLE
Do not export all internal symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,6 @@ project(fmu4cpp-template VERSION ${projectVersion})
 option(FMU4CPP_BUILD_TESTS "Build internal tests" OFF)
 
 set(CMAKE_CXX_STANDARD 17)
-if (MSVC)
-    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-endif ()
 
 
 ############modelIdentifier###################

--- a/export/src/CMakeLists.txt
+++ b/export/src/CMakeLists.txt
@@ -46,7 +46,7 @@ add_library(fmu4cpp OBJECT
         "${privateHeadersFull}"
         "${sources}"
         )
-target_compile_features(fmu4cpp PUBLIC "cxx_std_17")
+target_compile_features(fmu4cpp PRIVATE "cxx_std_17")
 set_target_properties(fmu4cpp PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(fmu4cpp
         PUBLIC

--- a/export/src/fmu4cpp/fmi2.cpp
+++ b/export/src/fmu4cpp/fmi2.cpp
@@ -41,7 +41,7 @@ const char *fmi2GetVersion(void) {
     return "2.0";
 }
 
-void write_description(const char *location) {
+FMI2_Export void write_description(const char *location) {
     const auto instance = fmu4cpp::createInstance("", "");
     const auto xml = instance->make_description();
     std::ofstream of(location);


### PR DESCRIPTION
I wondered why the generated MSVC DLL exported all internal C++ symbols. Actually this is not necessary since only the internal C function `write_description` is required for the post-build step.